### PR TITLE
Fix endgame module import for compilation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
-
 mod types;
 mod uci;
 mod board;
 mod movegen;
 mod search;
-mod perft;
 mod zobrist;
 mod tt;
 mod params;
+mod endgame;
+mod perft;
 
 use crate::uci::Uci;
 


### PR DESCRIPTION
## Summary
- declare `endgame` module in `main.rs` so search can access it

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c4b2bdbc888321bb063065edde9330