### PR TITLE
Prevent stability cutoff in infinite search

### DIFF
--- a/examples/infinite_stop.rs
+++ b/examples/infinite_stop.rs
@@ -1,0 +1,42 @@
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::Context;
+use hoplite::board::Board;
+use hoplite::eval::PsqtEvaluator;
+use hoplite::nnue;
+use hoplite::search::Search;
+
+fn main() -> anyhow::Result<()> {
+    let nnue_path = std::env::var("HOPLITE_NNUE")
+        .context("set HOPLITE_NNUE to the path of a valid NNUE network file")?;
+    let network = nnue::load_nnue(&nnue_path).context("failed to load NNUE network")?;
+    let mut search = Search::new(Some(Arc::new(network)))?;
+    search.set_threads(1);
+    search.set_evaluator(Arc::new(PsqtEvaluator));
+    search.set_min_depth(1);
+
+    // A quiet middlegame position that encourages deeper search iterations.
+    let mut board = Board::from_fen("4k3/8/8/8/8/8/2Q5/Q3K3 w - - 0 1")?;
+
+    let stop_flag = Arc::clone(&search.stop);
+    let stopper_flag = Arc::clone(&stop_flag);
+    let stopper = thread::spawn(move || {
+        thread::sleep(Duration::from_secs(120));
+        println!("Signalling stop flag...");
+        stopper_flag.store(true, Ordering::Relaxed);
+    });
+
+    let best_move = search.bestmove_infinite(&mut board);
+    println!("Search returned {}", best_move.uci());
+
+    stopper.join().expect("stopper thread panicked");
+    println!(
+        "Stop flag final value: {}",
+        stop_flag.load(Ordering::Relaxed)
+    );
+
+    Ok(())
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -367,7 +367,10 @@ impl Search {
                 if new_best.from == best.from && new_best.to == best.to {
                     stable_count += 1;
                     let depth_limit = dynamic_min_depth.max(6);
-                    if stable_count >= stability_limit && d >= depth_limit {
+                    if allow_stability_cutoff
+                        && stable_count >= stability_limit
+                        && d >= depth_limit
+                    {
                         break;
                     }
                 } else {
@@ -429,6 +432,7 @@ impl Search {
         self.nodes = 0;
         self.stop.store(false, Ordering::Relaxed);
         self.deadline = None;
+        let allow_stability_cutoff = self.deadline.is_some();
         let mut best = Move::default();
         let mut last_score: i16 = 0;
         let mut stable_count = 0; // Track stability
@@ -462,7 +466,10 @@ impl Search {
                 if new_best.from == best.from && new_best.to == best.to {
                     stable_count += 1;
                     let depth_limit = dynamic_min_depth.max(6);
-                    if stable_count >= stability_limit && d >= depth_limit {
+                    if allow_stability_cutoff
+                        && stable_count >= stability_limit
+                        && d >= depth_limit
+                    {
                         break;
                     }
                 } else {


### PR DESCRIPTION
## Summary
- gate the stability-based early exit in `bestmove_infinite` on whether a deadline is active
- add an `infinite_stop` example to manually verify that the infinite search respects the external stop flag

## Testing
- `cargo run --example infinite_stop`

------
https://chatgpt.com/codex/tasks/task_e_68ddbd6774c883218036dd873c7b22be